### PR TITLE
FRO-77: Adjust text and line size (under weather updates)...

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,9 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { BsGlobe } from 'react-icons/bs';
 import { BiSupport } from 'react-icons/bi';
 
 export default function Footer() {
+  useEffect(() => {
+    //  scroll to top on page load
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  }, []);
   return (
     <footer className="self-end pt-16 text-white bg-primary-btn-clicked">
       <div className="p-4 bg-[#B93815] md:py-10 md:px-16">
@@ -11,7 +15,15 @@ export default function Footer() {
           <div>
             <img src="/logo-white.png" alt="logo" />
             <div className="flex flex-col flex-wrap gap-6 mt-8 md:flex-row">
-              <Link to="/about-us" className="link link-hover">About us</Link>
+              <Link
+                onClick={() => {
+          window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+        }}
+                to="/about-us"
+                className="link link-hover"
+              >
+                About us
+              </Link>
               {/* <Link to="/promotions" className="link link-hover">Promotions</Link> */}
             </div>
           </div>

--- a/frontend/src/components/Home/HoulyUpdate.jsx
+++ b/frontend/src/components/Home/HoulyUpdate.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export default function HourlyUpdate({ time, day, forecast }) {
   return (
-    <article className="flex justify-between items-center border-b-2 border-[#DCDBE0] py-2">
+    <article className="flex justify-between items-center border-b-2 border-[rgba(220,219,224,0.4)] py-2">
       <div>
         <p>{time}</p>
         <p className="text-[#565560]">{day}</p>

--- a/frontend/src/components/Home/Risk.jsx
+++ b/frontend/src/components/Home/Risk.jsx
@@ -5,7 +5,7 @@ export default function Risk({ time, day, risk, chances }) {
   return (
     <article
       className="flex justify-between items-center
-     border-b-2 border-[#DCDBE0] py-2"
+     border-b-2 border-[rgba(220,219,224,0.4)] py-2"
     >
       <div className="flex items-center gap-4">
         <img src={`/Home/${risk.replace(' ', '-').toLowerCase()}.png`} alt="" />

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -90,7 +90,7 @@ export default function Home() {
           <div className="flex items-start justify-between">
             <div>
               <h3 className="landing_header_md">Weather Updates</h3>
-              <p className="text-[#565560]">Update a minute ago</p>
+              <p className="text-[#565560]">Updated a minute ago</p>
             </div>
             <button type="button" className="text-[#565560]">
               {' '}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -96,7 +96,7 @@ export default function Home() {
               {' '}
             </button>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px]">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-[100px]">
             <div className="rounded-lg shadow-md px-[10px] min-[350px]:px-[40px] py-4">
               <h5 className="mb-[32px] text-[20px] font-bold">
                 Hourly Updates


### PR DESCRIPTION
This PR contains the fix made on the Home page, lines opacity are neatly done, the Space-gap between the Hourly-update column and the Risk column has been done rationally.

[Link](https://linear.app/team-gear/issue/FRO-77/adjust-text-and-line-size-under-weather-updates) to issue


![fix on homepage](https://user-images.githubusercontent.com/105425844/205137002-4fa3dfb9-296d-45c9-812c-2b1ef06bc7d4.JPG)
